### PR TITLE
[refactor] Removes node-canvas dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,23 +110,22 @@ This algorithm allows multiple font characteristics, but only monospaced. Each f
 * **documentLines** The input lines, structured by its content, type, and further options, such as:
   * **text: string** The line text. It is required.
   * **type: string** The line type. This type must match with one of the types defined in the `types` parameter. All styles and properties used by the algorithm are based on the type definition. However, these properties can be overridden using specific values in each `documentLine`, as bellow. It is required.
-  * **[other options]** All options defined in `types` can be overridden in the scope of the line (except `fontConfig`). In that case, those specific options will apply only to the respective line. It is optional.
+  * **[other options]** All options defined in `types` can be overridden in the scope of the line. In that case, those specific options will apply only to the respective line. It is optional.
 * **types** A HashMap with all type definitions used by `documentLines`:
   * **[key]: string** The HashMap key is the type name. It is required.
   * **columns** Number of characters per line. This is recommended for monospace fonts, as it does not use complex calculations (drawing and measuring text on a canvas). If you intend to use non-monospaced fonts, use `width`.
-  * **width** Maximum line width in pixels. It is used especially for non-monospaced fonts. For monospace fonts, use `columns`.
+  * **width** Maximum line width in pixels. It is used especially for non-monospaced fonts and it uses a canvas instance passed by `options.canvas` to perform text dimensions calculation. For monospace fonts, use `columns`.
   * **marginTop: number** Top margin used to calculate the position of each line. The `margin-top` is used only in the first wrapped line of each input line. It is optional.
   * **marginBottom: number** Bottom margin used to calculate the position of each line. The `margin-bottom` is used only in the last wrapped line of each input line. It is optional.
   * **lineHeight: number** The height of each line of this type. It is optional.
   * **visible: number** When `visible` is `false`, lines of this type do not affect the position of other lines. It is optional.
-  * **font: string** The font to be applied to the text, using the [`CanvasRenderingContext2D.font`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font) format. It is optional. The default value is `13px Courier, monospace`.
-  * **fontConfig: any** If you want to use external fonts, you should specify its location and properties. It is optional. These options are used in [`registerFont`](https://github.com/Automattic/node-canvas#registerfont) method. With the exception of the `path`, all other properties with properties resemble the CSS properties that are specified in `@font-face rules`. You must specify at least `family`. The`weight` and `style` are optional and default to `normal`.
-      * **path: string** The `.ttf` file path.
-      * **family: string** The font family name. E.g.: `Roboto`, `Comic Sans`.
-      * **weight: string** The font weight. E.g.: `bold`, `300`.
-      * **style: string** The font style. E.g.: `italic`.
+  * **font: string** The font to be applied to the text. It is optional and it is not applied if you are using `columns`. The default value is `13px Courier, monospace`. Fonts must be preloaded into the `canvas` instance.
 * **options**
   * **browser: string** Line-breaking algorithms may differ from browser to browser. So far, only the Google Chrome browser is supported. The default value is `chrome`.
+  * **canvas: any** A canvas instance where `width` calculations will be performed, using its 2D Context. It is optional for `columns` calculation. If you are using `width`, you must use a canvas. It depends on the environment, for instance:
+      * **Browsers** You can use `document.createElement('canvas')`.
+      * **Node.js** You can use an instance of [node-canvas](https://github.com/Automattic/node-canvas).
+      * **Workers** You can use an instance of [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas).
   * **richOutput: boolean** Setting this option to `false`, an array of strings will be returned. When it is `true`, an array of objects is returned such as
       > ```ts
       > [{
@@ -169,12 +168,6 @@ const types = {
     marginBottom: 10,
     lineHeight: 5,
     font: '300 15px Roboto, sans-serif',
-    fontConfig: {
-      family: 'Roboto',
-      weight: '300',
-      style: 'normal',
-      path: '/path/of/my/fonts/Roboto-Light.ttf',
-    },
   },
   type_2: {
     columns: 9,

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -333,19 +333,8 @@ class ChromeRobustTextWrapper {
   }
 
   initializeWidthCalculator() {
-    const { types } = this.options;
-
-    const isEqual = (fontA, fontB) => fontA.path === fontB.path;
-    const distinctFontFilter = (type, index, self) => (
-      self.findIndex((i) => isEqual(type.fontConfig, i.fontConfig)) === index
-    );
-
-    const fonts = Object.values(types)
-      .filter((type) => !!type.fontConfig)
-      .filter(distinctFontFilter)
-      .map((type) => type.fontConfig);
-
-    this.textWidthCalculator = new TextWidthCalculator(fonts);
+    const { canvas } = this.options;
+    this.textWidthCalculator = new TextWidthCalculator(canvas);
   }
 }
 

--- a/lib/textWidthCalculator.js
+++ b/lib/textWidthCalculator.js
@@ -1,24 +1,13 @@
-const { registerFont, createCanvas } = require('canvas');
-
 const WHITESPACE = ' ';
 
 class TextWidthCalculator {
-  constructor(fonts = []) {
-    this._initializeFonts(fonts);
-    this._initializeCanvas();
+  constructor(canvas) {
+    this._initializeCanvasContext(canvas);
     this._initializeCache();
   }
 
-  _initializeFonts(fonts) {
-    fonts.forEach((font) => {
-      const { path: fontPath, ...fontProps } = font;
-      registerFont(fontPath, fontProps);
-    });
-  }
-
-  _initializeCanvas() {
-    this.canvas = createCanvas(0, 0);
-    this.canvasContext = this.canvas.getContext('2d');
+  _initializeCanvasContext(canvas) {
+    this.canvasContext = canvas.getContext('2d');
   }
 
   _initializeCache() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wrap-text",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "acorn": {
       "version": "7.3.1",
@@ -135,12 +136,14 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -237,7 +240,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.3.1",
@@ -255,6 +259,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -505,6 +510,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.1.tgz",
       "integrity": "sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==",
+      "dev": true,
       "requires": {
         "nan": "^2.14.0",
         "node-pre-gyp": "^0.11.0",
@@ -566,7 +572,8 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -581,7 +588,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -613,7 +621,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -642,7 +651,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -665,7 +675,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -761,6 +772,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
       "requires": {
         "mimic-response": "^2.0.0"
       }
@@ -768,7 +780,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -794,7 +807,8 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "deps-sort": {
       "version": "2.0.1",
@@ -821,7 +835,8 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "detective": {
       "version": "5.2.0",
@@ -1276,6 +1291,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
       "requires": {
         "minipass": "^2.6.0"
       }
@@ -1283,7 +1299,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1301,6 +1318,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -1315,12 +1333,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1329,6 +1349,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1339,6 +1360,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1355,6 +1377,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1412,7 +1435,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "hash-base": {
       "version": "3.1.0",
@@ -1487,6 +1511,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -1507,6 +1532,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -1531,6 +1557,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1539,12 +1566,14 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -1612,7 +1641,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -1650,7 +1680,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1802,7 +1833,8 @@
     "mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -1820,6 +1852,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1827,12 +1860,14 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -1842,6 +1877,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
       "requires": {
         "minipass": "^2.9.0"
       }
@@ -1850,6 +1886,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -1886,12 +1923,14 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1903,6 +1942,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
       "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "dev": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -1913,6 +1953,7 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1923,6 +1964,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
       "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "dev": true,
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -1939,7 +1981,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -1947,6 +1990,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
       "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -1976,6 +2020,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
       "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "dev": true,
       "requires": {
         "npm-normalize-package-bin": "^1.0.1"
       }
@@ -1983,12 +2028,14 @@
     "npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "npm-packlist": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
       "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -1999,6 +2046,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -2009,12 +2057,14 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.8.0",
@@ -2067,6 +2117,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2094,17 +2145,20 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -2196,7 +2250,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -2268,7 +2323,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -2348,6 +2404,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2358,7 +2415,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -2396,6 +2454,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2431,6 +2490,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2448,17 +2508,20 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.2",
@@ -2469,7 +2532,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -2524,17 +2588,20 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
     },
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
     },
     "simple-get": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
       "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
       "requires": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -2703,6 +2770,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -2771,6 +2839,7 @@
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
       "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -2950,7 +3019,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -2987,6 +3057,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
@@ -2994,12 +3065,14 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -3009,6 +3082,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -3024,7 +3098,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -3050,7 +3125,8 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,10 @@
   "homepage": "https://github.com/storytouch/wrap-text#readme",
   "devDependencies": {
     "browserify": "^16.5.1",
+    "canvas": "^2.6.1",
     "eslint": "^7.3.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.21.2",
     "testit": "^3.1.0"
-  },
-  "dependencies": {
-    "canvas": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wrap-text",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A simple tool for wrapping words to the specified column width.",
   "main": "index.js",
   "scripts": {

--- a/test/benchmark/benchmark.js
+++ b/test/benchmark/benchmark.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const { wrapTextRobust } = require('../../index.js');
+const { createCanvas } = require('../utils/canvas');
 
 const textFixture = require('../fixtures/benchmark-text.json').text;
 
@@ -8,11 +9,13 @@ const NUMBER_OF_INPUT_LINES = 2000;
 const FONT_DRIVEN_TYPE = 'FONT_DRIVEN_TYPE';
 const COLUMN_DRIVEN_TYPE = 'COLUMN_DRIVEN_TYPE';
 
+const isRunningOnBrowser = typeof window !== 'undefined';
+
 const printAgent = () => {
-  if (typeof window === 'undefined') {
-    console.log('Running on Node.js');
-  } else {
+  if (isRunningOnBrowser) {
     console.log('Running on Browser');
+  } else {
+    console.log('Running on Node.js');
   }
   console.log('==================');
 };
@@ -38,10 +41,18 @@ const types = {
   },
 };
 
+const canvas = isRunningOnBrowser
+  ? document.createElement('canvas')
+  : createCanvas();
+
+const options = {
+  canvas,
+};
+
 const performBenchmarkTest = (numberOfParagraphs, type) => {
   const documentLines = generateLongText(numberOfParagraphs, type);
   console.time(type);
-  const output = wrapTextRobust(documentLines, types);
+  const output = wrapTextRobust(documentLines, types, options);
   console.log('Number of input lines: ', numberOfParagraphs);
   console.log('Number of output lines: ', output.length);
   console.timeEnd(type);

--- a/test/fixtures/complex-text.json
+++ b/test/fixtures/complex-text.json
@@ -32,25 +32,13 @@
       "lineHeight": 18,
       "marginTop": 20,
       "marginBottom": 5,
-      "font": "300 14px Roboto, sans-serif",
-      "fontConfig": {
-        "family": "Roboto",
-        "weight": "300",
-        "style": "normal",
-        "path": "/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf"
-      }
+      "font": "300 14px Roboto, sans-serif"
     },
     "scene_mark_summary": {
       "width": 547,
       "lineHeight": 18,
       "marginTop": 0,
-      "font": "300 14px Roboto, sans-serif",
-      "fontConfig": {
-        "family": "Roboto",
-        "weight": "300",
-        "style": "normal",
-        "path": "/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf"
-      }
+      "font": "300 14px Roboto, sans-serif"
     },
     "shot": {
       "columns": 61,
@@ -145,6 +133,14 @@
     {
       "text": "VIVAMUS NON IMPERDIET IPSUM, NON ACCUMSAN JUSTO. SED EGET FEUGIAT LECTUS. AENEAN NON EGESTAS LIBERO. DONEC EGESTAS URNA MATTIS CONVALLIS MAXIMUS.",
       "type": "shot"
+    }
+  ],
+  "fonts": [
+    {
+      "family": "Roboto",
+      "weight": "300",
+      "style": "normal",
+      "path": "/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf"
     }
   ],
   "expectedOutput": [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const test = require('testit');
 
+const { createCanvas } = require('./utils/canvas');
 const { wrapText, wrapTextRobust } = require('..');
 
 test('wrapText()', () => {
@@ -69,6 +70,7 @@ test('wrapTextRobust()', () => {
 
     options = {
       richOutput: true,
+      canvas: createCanvas(),
     };
 
     test('does not throw any error', () => {
@@ -77,10 +79,9 @@ test('wrapTextRobust()', () => {
     });
   });
 
-  test('with no options', () => {
-    test('does not throw any error', () => {
-      const result = wrapTextRobust(documentLines, types);
-      assert(Array.isArray(result));
+  test('with no canvas option', () => {
+    test('throws an error', () => {
+      assert.throws(() => wrapTextRobust(documentLines, types, {}));
     });
   });
 

--- a/test/lib/chromeRobustTextWrapper.spec.js
+++ b/test/lib/chromeRobustTextWrapper.spec.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const test = require('testit');
 const ChromeRobustTextWrapper = require('../../lib/chromeRobustTextWrapper');
 const complexTextFixture = require('../fixtures/complex-text.json');
+const { createCanvas } = require('../utils/canvas');
 
 let documentLines;
 let types;
@@ -29,8 +30,12 @@ test('ChromeRobustTextWrapper', () => {
       type: 'any_type',
     }];
 
+    options = {
+      canvas: createCanvas(),
+    };
+
     test('all lines should have a maximum of the type width + 1 whitespace', () => {
-      const result = subject(documentLines, types);
+      const result = subject(documentLines, types, options);
       result.forEach((line) => assert(line.length <= 16));
     });
 
@@ -42,19 +47,22 @@ test('ChromeRobustTextWrapper', () => {
         'adipiscing ',
         'elit.',
       ];
-      const result = subject(documentLines, types);
+      const result = subject(documentLines, types, options);
       assert.deepEqual(result, expectedLines);
     });
 
     test('preserves the original text', () => {
-      const result = subject(documentLines, types);
+      const result = subject(documentLines, types, options);
       const reconstuctedText = result.join('');
       const originalText = documentLines.map((entry) => entry.text).join('\n');
       assert.deepEqual(reconstuctedText, originalText);
     });
 
     test('and the richOutput options is enabled', () => {
-      options = { richOutput: true };
+      options = {
+        richOutput: true,
+        canvas: createCanvas(),
+      };
 
       test('returns each line with its expected offset and length', () => {
         const result = subject(documentLines, types, options);
@@ -82,12 +90,6 @@ test('ChromeRobustTextWrapper', () => {
         marginBottom: 10,
         lineHeight: 5,
         font: '300 15px Roboto, sans-serif',
-        fontConfig: {
-          family: 'Roboto',
-          weight: '300',
-          style: 'normal',
-          path: '/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf',
-        },
       },
       type_2: {
         columns: 9,
@@ -108,8 +110,16 @@ test('ChromeRobustTextWrapper', () => {
       type: 'type_2',
     }];
 
+    const fonts = [{
+      family: 'Roboto',
+      weight: '300',
+      style: 'normal',
+      path: '/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf',
+    }];
+
     options = {
       richOutput: true,
+      canvas: createCanvas(fonts),
     };
 
     test('returns the expected text of each line', () => {
@@ -191,10 +201,13 @@ test('ChromeRobustTextWrapper', () => {
   });
 
   test('with a complex text', () => {
-    const { expectedOutput } = complexTextFixture;
+    const { expectedOutput, fonts } = complexTextFixture;
     types = complexTextFixture.types;
     documentLines = complexTextFixture.documentLines;
-    options = { richOutput: true };
+    options = {
+      richOutput: true,
+      canvas: createCanvas(fonts),
+    };
 
     test('produces the expected lines', () => {
       const result = subject(documentLines, types, options);

--- a/test/lib/textWidthCalculator.spec.js
+++ b/test/lib/textWidthCalculator.spec.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const test = require('testit');
 
+const { createCanvas } = require('../utils/canvas');
 const TextWidthCalculator = require('../../lib/textWidthCalculator');
 
 const MEASUREMENT_ERROR_TOLERANCE = 2.0; // in pixels
@@ -13,39 +14,41 @@ test('TextWidthCalculator', () => {
   test('calculateWidth()', () => {
     let word;
     let font;
-    let fonts;
+    let canvas;
 
-    const subject = (_fonts, _word, _font) => {
-      const calculator = new TextWidthCalculator(_fonts);
+    const subject = (_canvas, _word, _font) => {
+      const calculator = new TextWidthCalculator(_canvas);
       return calculator.calculateWidth(_word, _font);
     };
 
     test('with default font', () => {
       word = 'Hello';
       font = null;
-      fonts = [];
+      canvas = createCanvas();
 
       test('returns the expected width within a tolerance', () => {
         const reference = 39.05712890625;
-        const result = subject(fonts, word, font);
+        const result = subject(canvas, word, font);
         const error = getMeasurementError(result, reference);
         assert(error < MEASUREMENT_ERROR_TOLERANCE);
       });
     });
 
     test('with a custom font', () => {
-      word = 'Hello';
-      font = '300 14px Roboto, sans-serif';
-      fonts = [{
+      const fonts = [{
         family: 'Roboto',
         weight: '300',
         style: 'normal',
         path: '/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf',
       }];
 
+      word = 'Hello';
+      font = '300 14px Roboto, sans-serif';
+      canvas = createCanvas(fonts);
+
       test('returns the expected width within a tolerance', () => {
         const reference = 32.47995483875275;
-        const result = subject(fonts, word, font);
+        const result = subject(canvas, word, font);
         const error = getMeasurementError(result, reference);
         assert(error < MEASUREMENT_ERROR_TOLERANCE);
       });

--- a/test/utils/canvas.js
+++ b/test/utils/canvas.js
@@ -1,0 +1,16 @@
+const {
+  registerFont,
+  createCanvas: createNodeCanvas,
+} = require('canvas');
+
+const registerFonts = (fonts) => {
+  fonts.forEach((font) => {
+    const { path: fontPath, ...fontProps } = font;
+    registerFont(fontPath, fontProps);
+  });
+};
+
+exports.createCanvas = (fonts = []) => {
+  registerFonts(fonts);
+  return createNodeCanvas(0, 0);
+};


### PR DESCRIPTION
This PR removes the main dependency [node-canvas](https://github.com/Automattic/node-canvas) (used only in test now) in the **Robust** algorithm. Now, users must pass a `canvas` instance as a parameter for `width` calculations. For `columns` calculations, nothing was changed.

This change makes the library more flexible for different environments, such as Browsers, Node.js and Workers.

Main changes:
- `type.fontConfig` is not used anymore
- `options.canvas` added