### PR TITLE
[refactor] Allow the use of extended metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This algorithm allows multiple font characteristics, but only monospaced. Each f
       * **Browsers** You can use `document.createElement('canvas')`.
       * **Node.js** You can use an instance of [node-canvas](https://github.com/Automattic/node-canvas).
       * **Workers** You can use an instance of [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas).
+  * **useExtendedMetrics: boolean** Enables the use of `actualBoundingBoxLeft` and `actualBoundingBoxRight` of `TextMetrics` object to perform a more accurate `width` estimation. It is optional and the default value is `false`.
   * **richOutput: boolean** Setting this option to `false`, an array of strings will be returned. When it is `true`, an array of objects is returned such as
       > ```ts
       > [{

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -324,6 +324,7 @@ class ChromeRobustTextWrapper {
   setOptions(options) {
     const defaultOptions = {
       richOutput: false,
+      useExtendedMetrics: false,
     };
 
     this.options = {
@@ -333,8 +334,8 @@ class ChromeRobustTextWrapper {
   }
 
   initializeWidthCalculator() {
-    const { canvas } = this.options;
-    this.textWidthCalculator = new TextWidthCalculator(canvas);
+    const { canvas, useExtendedMetrics } = this.options;
+    this.textWidthCalculator = new TextWidthCalculator(canvas, useExtendedMetrics);
   }
 }
 

--- a/lib/textWidthCalculator.js
+++ b/lib/textWidthCalculator.js
@@ -1,7 +1,8 @@
 const WHITESPACE = ' ';
 
 class TextWidthCalculator {
-  constructor(canvas) {
+  constructor(canvas, useExtendedMetrics = false) {
+    this.useExtendedMetrics = useExtendedMetrics;
     this._initializeCanvasContext(canvas);
     this._initializeCache();
   }
@@ -31,7 +32,28 @@ class TextWidthCalculator {
 
     // measure the text
     const textMetrics = this.canvasContext.measureText(word);
-    const { width } = textMetrics;
+
+    // default width metric
+    let { width } = textMetrics;
+
+    // When measuring the x-direction of a piece of text,
+    // the sum of actualBoundingBoxLeft and actualBoundingBoxRight
+    // can be wider than the width of the inline box (width), due to
+    // slanted/italic fonts where characters overhang their advance width.
+    // ref: https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics
+
+    // It can therefore be useful to use the sum of actualBoundingBoxLeft
+    // and actualBoundingBoxRight as a more accurate way to get the
+    // absolute text width:
+    if (this.useExtendedMetrics) {
+      const supportExtendedMetrics = 'actualBoundingBoxLeft' in textMetrics && 'actualBoundingBoxRight' in textMetrics;
+      if (!supportExtendedMetrics) {
+        throw new Error('Extended properties of TextMetrics are not supported.');
+      }
+
+      const { actualBoundingBoxLeft, actualBoundingBoxRight } = textMetrics;
+      width = Math.abs(actualBoundingBoxLeft) + Math.abs(actualBoundingBoxRight);
+    }
 
     return width;
   }

--- a/test/lib/textWidthCalculator.spec.js
+++ b/test/lib/textWidthCalculator.spec.js
@@ -15,9 +15,10 @@ test('TextWidthCalculator', () => {
     let word;
     let font;
     let canvas;
+    let useExtendedMetrics;
 
-    const subject = (_canvas, _word, _font) => {
-      const calculator = new TextWidthCalculator(_canvas);
+    const subject = (_canvas, _word, _font, _useExtendedMetrics) => {
+      const calculator = new TextWidthCalculator(_canvas, _useExtendedMetrics);
       return calculator.calculateWidth(_word, _font);
     };
 
@@ -47,10 +48,40 @@ test('TextWidthCalculator', () => {
       canvas = createCanvas(fonts);
 
       test('returns the expected width within a tolerance', () => {
-        const reference = 32.47995483875275;
+        const reference = 31;
         const result = subject(canvas, word, font);
         const error = getMeasurementError(result, reference);
         assert(error < MEASUREMENT_ERROR_TOLERANCE);
+      });
+
+      test('using extented metrics', () => {
+        useExtendedMetrics = true;
+
+        test('returns the expected width within a tolerance', () => {
+          const reference = 31;
+          const result = subject(canvas, word, font, useExtendedMetrics);
+          const error = getMeasurementError(result, reference);
+          assert(error < MEASUREMENT_ERROR_TOLERANCE);
+        });
+
+        test('and when the canvas does not support extended metrics', () => {
+          const mockedCanvas2DContext = {
+            measureText: (text) => {
+              const realContext = canvas.getContext('2d');
+              const realMetrics = realContext.measureText(text);
+              const { width } = realMetrics;
+              return { width };
+            },
+          };
+
+          const mockedCanvas = createCanvas(fonts);
+          mockedCanvas.getContext = () => mockedCanvas2DContext;
+
+          test('throws an error', () => {
+            assert.throws(() => subject(mockedCanvas, word, font, useExtendedMetrics),
+              Error, 'Extended properties of TextMetrics are not supported.');
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
This PR adds a new option in the Robust algorithm called `useExtendMetrics`, that enable the use of `actualBoundingBoxLeft` and `actualBoundingBoxRight` of `TextMetrics` object to perform a more accurate `width` estimation.