### PR TITLE
[feat] Allow custom line markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ This algorithm allows multiple font characteristics, but only monospaced. Each f
       * **Node.js** You can use an instance of [node-canvas](https://github.com/Automattic/node-canvas).
       * **Workers** You can use an instance of [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas).
   * **useExtendedMetrics: boolean** Enables the use of `actualBoundingBoxLeft` and `actualBoundingBoxRight` of `TextMetrics` object to perform a more accurate `width` estimation. It is optional and the default value is `false`.
+  * **marker: function** A custom mark that is applied to each line. This function receives the `context` and `index` as parameters and must return an object. It is optional. E.g:
+      > ```js
+      > options = {
+      >   marker: (context, index) => ({
+      >     even: i % 2 === 0,
+      >     odd: i % 2 !== 0,
+      >     jedi: (context.type === 'master' || context.type === 'padawan'),
+      >   })
+      > }
+      > ```
   * **richOutput: boolean** Setting this option to `false`, an array of strings will be returned. When it is `true`, an array of objects is returned such as
       > ```ts
       > [{

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -141,9 +141,11 @@ class ChromeRobustTextWrapper {
     const { text } = this.buffer;
     const dimensions = this.calculateLineDimensions(context);
     const index = this.outputLines.length;
+    const marker = this.getMarker(context, index);
 
     this.outputLines.push({
       ...dimensions,
+      ...marker,
       index,
       parentIndex,
       text,
@@ -325,6 +327,7 @@ class ChromeRobustTextWrapper {
     const defaultOptions = {
       richOutput: false,
       useExtendedMetrics: false,
+      marker: null,
     };
 
     this.options = {
@@ -336,6 +339,14 @@ class ChromeRobustTextWrapper {
   initializeWidthCalculator() {
     const { canvas, useExtendedMetrics } = this.options;
     this.textWidthCalculator = new TextWidthCalculator(canvas, useExtendedMetrics);
+  }
+
+  getMarker(context, index) {
+    const userMarkerFunction = this.options.marker;
+    if (typeof userMarkerFunction === 'function') {
+      return userMarkerFunction.apply(null, [context, index]);
+    }
+    return undefined;
   }
 }
 

--- a/test/lib/chromeRobustTextWrapper.spec.js
+++ b/test/lib/chromeRobustTextWrapper.spec.js
@@ -117,9 +117,23 @@ test('ChromeRobustTextWrapper', () => {
       path: '/usr/src/app/test/fixtures/fonts/Roboto/Roboto-Light.ttf',
     }];
 
+    // E.g: let's mark every type transition
+    const marker = () => {
+      let lastType = null;
+      return (context, index) => {
+        const currentType = context.type;
+        const isTransition = index > 0 && currentType !== lastType;
+        lastType = currentType;
+        return {
+          transition: isTransition,
+        };
+      };
+    };
+
     options = {
       richOutput: true,
       canvas: createCanvas(fonts),
+      marker: marker(),
     };
 
     test('returns the expected text of each line', () => {
@@ -197,6 +211,12 @@ test('ChromeRobustTextWrapper', () => {
         const textSubstr = allText.substr(entry.offset, entry.length);
         assert.deepEqual(entry.text, textSubstr);
       });
+    });
+
+    test('returns the expected marker of each line', () => {
+      const expectedValues = [false, false, false, true, false];
+      const result = subject(documentLines, types, options);
+      assert.deepEqual(result.map((entry) => entry.transition), expectedValues);
     });
   });
 


### PR DESCRIPTION
This PR allows using a custom line `marker` in the *Robust* algorithm, which is applied to each line. This `marker` function receives the `context` and `index` as parameters and must return an object. Is optional. E.g:

 ```js
options = {
  marker: (context, index) => ({
    even: i % 2 === 0,
    odd: i % 2 !== 0,
    jedi: (context.type === 'master' || context.type === 'padawan'),
  })
}
```