### PR TITLE
[refactor] Handle multiple white-spaces sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const output = wrapText(input, 15, { richOutput: true });
 > wrapTextRobust(documentLines: any[], types: Array<{[string]: any}>, options?: any) => any[]
 > ```
 
-This algorithm allows multiple font characteristics, but only monospaced. Each font property, such as width, margins, and line-height, is mapped to a defined type.
+This algorithm reproduces the CSS `white-space: pre-wrap; word-break: break-word;` output and allows multiple font characteristics. Each font property, such as width, margins, and line-height, is mapped to a defined type.
 
 * **documentLines** The input lines, structured by its content, type, and further options, such as:
   * **text: string** The line text. It is required.

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -107,8 +107,10 @@ class ChromeRobustTextWrapper {
       if (inputLine.length === 0) {
         this.appendNewLine(context);
       } else {
-        const words = inputLine.split(' ');
-        words.forEach((word, wordIndex) => {
+        const inputLineWithNbsp = this.encodeNonBreakingSpaces(inputLine);
+        const words = inputLineWithNbsp.split(' ');
+        words.forEach((wordWithNbsp, wordIndex) => {
+          const word = this.decodeNonBreakingSpaces(wordWithNbsp);
           const isLastWord = wordIndex === words.length - 1;
           this.appendWord(word, context);
           if (isLastWord) {
@@ -347,6 +349,22 @@ class ChromeRobustTextWrapper {
       return userMarkerFunction.apply(null, [context, index]);
     }
     return undefined;
+  }
+
+  /* As we could observe on Chrome, consecutive
+   * whitespaces are encoded into non-braking spaces
+   * using the &nbsp; HTML entity.
+   * If there is a non-space character after a whitespace
+   * sequence, the last whitespace is not encoded [1].
+  */
+  encodeNonBreakingSpaces(text) {
+    return text
+      .replace(/\s/g, '&nbsp;')
+      .replace(/&nbsp;([^&])/g, ' $1'); // [1]
+  }
+
+  decodeNonBreakingSpaces(text) {
+    return text.replace(/&nbsp;/g, ' ');
   }
 }
 

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -351,9 +351,9 @@ class ChromeRobustTextWrapper {
     return undefined;
   }
 
-  /* As we could observe on Chrome, consecutive
-   * whitespaces are encoded into non-braking spaces
-   * using the &nbsp; HTML entity.
+  /* As we could observe on Chrome 85.0.4183.102,
+   * consecutive whitespaces are encoded into
+   * non-braking spaces using the &nbsp; HTML entity.
    * If there is a non-space character after a whitespace
    * sequence, the last whitespace is not encoded [1].
   */

--- a/test/lib/chromeRobustTextWrapper.spec.js
+++ b/test/lib/chromeRobustTextWrapper.spec.js
@@ -270,4 +270,82 @@ test('ChromeRobustTextWrapper', () => {
       }
     });
   });
+
+  test('when there are multiple whitespace at the begining of the line', () => {
+    types = {
+      any_type: {
+        columns: 12,
+      },
+    };
+
+    documentLines = [{
+      text: '       Lorem ipsum.',
+      type: 'any_type',
+    }];
+
+    options = {
+      canvas: createCanvas(),
+    };
+
+    test('returns the expected lines', () => {
+      const expectedLines = [
+        '       Lorem ',
+        'ipsum.',
+      ];
+      const result = subject(documentLines, types, options);
+      assert.deepEqual(result, expectedLines);
+    });
+  });
+
+  test('when there are multiple whitespace at the middle of the line', () => {
+    types = {
+      any_type: {
+        columns: 12,
+      },
+    };
+
+    documentLines = [{
+      text: 'Lorem          ipsum.',
+      type: 'any_type',
+    }];
+
+    options = {
+      canvas: createCanvas(),
+    };
+
+    test('returns the expected lines', () => {
+      const expectedLines = [
+        'Lorem       ',
+        '   ipsum.',
+      ];
+      const result = subject(documentLines, types, options);
+      assert.deepEqual(result, expectedLines);
+    });
+  });
+
+  test('when there are whitespace at the end of the line', () => {
+    types = {
+      any_type: {
+        columns: 12,
+      },
+    };
+
+    documentLines = [{
+      text: 'Lorem ipsum.  ',
+      type: 'any_type',
+    }];
+
+    options = {
+      canvas: createCanvas(),
+    };
+
+    test('returns the expected lines', () => {
+      const expectedLines = [
+        'Lorem ',
+        'ipsum.  ',
+      ];
+      const result = subject(documentLines, types, options);
+      assert.deepEqual(result, expectedLines);
+    });
+  });
 });

--- a/test/lib/chromeRobustTextWrapper.spec.js
+++ b/test/lib/chromeRobustTextWrapper.spec.js
@@ -297,7 +297,7 @@ test('ChromeRobustTextWrapper', () => {
     });
   });
 
-  test('when there are multiple whitespace at the middle of the line', () => {
+  test('when there are multiple whitespace in the middle of the line', () => {
     types = {
       any_type: {
         columns: 12,

--- a/test/reference.html
+++ b/test/reference.html
@@ -27,6 +27,12 @@
       #e, #f {
         width: 61ch;
       }
+
+      #g, #h, #i {
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
+        width: 12ch;
+      }
     </style>
   </head>
   <body>
@@ -53,6 +59,15 @@
 
     <h4>F</h4>
     <div id="f"><span>Quisque convallis dolor felis, sed venenatis mi sagittis rutrum. Nam vel ligula aliquam, tempus augue ac, iaculis nisl.</span></div>
+
+    <h4>G</h4>
+    <div id="g"><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Lorem ipsum.</span></div>
+
+    <h4>H</h4>
+    <div id="h"><span>Lorem&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ipsum.</span></div>
+
+    <h4>I</h4>
+    <div id="i"><span>Lorem ipsum.&nbsp;&nbsp;</span></div>
   </body>
 </html>
 


### PR DESCRIPTION
This commit handles texts with multiple white-spaces sequences by enconding them into non-breaking spaces.
On Chrome, this approach uses the HTML Entity `&nbsp;` following some rules that might differ from other browsers.