### PR TITLE
[feat] Allows to return the hash of each line

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ This algorithm reproduces the CSS `white-space: pre-wrap; word-break: break-word
       * **Node.js** You can use an instance of [node-canvas](https://github.com/Automattic/node-canvas).
       * **Workers** You can use an instance of [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas).
   * **useExtendedMetrics: boolean** Enables the use of `actualBoundingBoxLeft` and `actualBoundingBoxRight` of `TextMetrics` object to perform a more accurate `width` estimation. It is optional and the default value is `false`.
+  * **hasher: function** A hash function that is used to calculate the hash of each output line. This function receives `line` as parameter and must return its hash string. It is useful to compare two sets of lines and detect where they differ. It is optional. E.g:
+      > ```js
+      > const hasher = require('node-object-hash');
+      > const hashSort = hasher({ sort: true, coerce: false });
+      >
+      > options = {
+      >   hasher: (line) => hashSort.hash(line),
+      >   richOutput: true,
+      > }
+      > ```
   * **marker: function** A custom mark that is applied to each line. This function receives the `context` and `index` as parameters and must return an object. It is optional. E.g:
       > ```js
       > options = {
@@ -137,6 +147,7 @@ This algorithm reproduces the CSS `white-space: pre-wrap; word-break: break-word
   * **richOutput: boolean** Setting this option to `false`, an array of strings will be returned. When it is `true`, an array of objects is returned such as
       > ```ts
       > [{
+      >   hash: string,
       >   height: number,
       >   length: number,
       >   marginBottom: number,
@@ -151,6 +162,7 @@ This algorithm reproduces the CSS `white-space: pre-wrap; word-break: break-word
       >   y0: number,
       > }]
       > ```
+      * **hash** The line hash that is calculated if a `hasher` function is provided.
       * **height** The line height.
       * **length** Number of characters in the line.
       * **marginBottom** The line margin-bottom.

--- a/lib/chromeRobustTextWrapper.js
+++ b/lib/chromeRobustTextWrapper.js
@@ -214,9 +214,13 @@ class ChromeRobustTextWrapper {
 
   buildOutput() {
     const { richOutput } = this.options;
-    return richOutput
-      ? this.outputLines
-      : this.outputLines.map((entry) => entry.text);
+
+    if (richOutput) {
+      this.hashLines(this.outputLines);
+      return this.outputLines;
+    }
+
+    return this.outputLines.map((entry) => entry.text);
   }
 
   chunkWord(str) {
@@ -330,6 +334,7 @@ class ChromeRobustTextWrapper {
       richOutput: false,
       useExtendedMetrics: false,
       marker: null,
+      hasher: null,
     };
 
     this.options = {
@@ -344,11 +349,20 @@ class ChromeRobustTextWrapper {
   }
 
   getMarker(context, index) {
-    const userMarkerFunction = this.options.marker;
+    const { marker: userMarkerFunction } = this.options;
     if (typeof userMarkerFunction === 'function') {
       return userMarkerFunction.apply(null, [context, index]);
     }
     return undefined;
+  }
+
+  hashLines(lines) {
+    const { hasher: userHashFunction } = this.options;
+    if (typeof userHashFunction === 'function') {
+      lines.forEach((line) => {
+        line.hash = userHashFunction.apply(null, [line]);
+      });
+    }
   }
 
   /* As we could observe on Chrome 85.0.4183.102,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,6 +1960,12 @@
         }
       }
     },
+    "node-object-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-2.0.0.tgz",
+      "integrity": "sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ==",
+      "dev": true
+    },
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "eslint": "^7.3.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.21.2",
+    "node-object-hash": "^2.0.0",
     "testit": "^3.1.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/test/lib/chromeRobustTextWrapper.spec.js
+++ b/test/lib/chromeRobustTextWrapper.spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const test = require('testit');
+const hasher = require('node-object-hash');
 const ChromeRobustTextWrapper = require('../../lib/chromeRobustTextWrapper');
 const complexTextFixture = require('../fixtures/complex-text.json');
 const { createCanvas } = require('../utils/canvas');
@@ -78,6 +79,21 @@ test('ChromeRobustTextWrapper', () => {
         const expectedY0 = [0, 12, 17, 22, 27];
         const result = subject(documentLines, types, options);
         assert.deepEqual(result.map((entry) => entry.y0), expectedY0);
+      });
+
+      test('and a hash function is provided', () => {
+        const hashSort = hasher({ sort: true, coerce: false });
+
+        options = {
+          hasher: (line) => hashSort.hash(line),
+          richOutput: true,
+          canvas: createCanvas(),
+        };
+
+        test('returns the hash of each line', () => {
+          const result = subject(documentLines, types, options);
+          assert(result.every((entry) => entry.hash.length > 0));
+        });
       });
     });
   });


### PR DESCRIPTION
This PR allows returning the hash code of each output line by providing a `hasher` function in the `options`.  This feature is useful to compare two sets of output lines and detect where they differ.